### PR TITLE
Update Docker release GHA to include tag v prefix

### DIFF
--- a/.github/workflows/dockerhub.yaml
+++ b/.github/workflows/dockerhub.yaml
@@ -29,7 +29,7 @@ jobs:
         with:
           images: materialize/ephemeral-storage-setup-image
           tags: |
-            type=semver,pattern={{version}}
+            type=semver,pattern=v{{version}}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v6


### PR DESCRIPTION
Open to suggestions if we should add the `v*` in the Docker image tag.