### PR TITLE
Add sleep command, to avoid need for pause images

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,9 @@ resource "kubernetes_daemonset" "disk_setup" {
         }
         container {
           name  = "pause"
-          image = "gcr.io/google_containers/pause:3.2"
+          image = var.disk_setup_image
+          command = ["ephemeral-storage-setup"]
+          args    = ["sleep"]
           resources {
             limits = {
               memory = "8Mi"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,6 @@
+use std::thread::sleep;
+use std::time::Duration;
+
 use clap::{Parser, Subcommand};
 
 use ephemeral_storage_setup::detect::DiskDetector;
@@ -44,6 +47,10 @@ enum Commands {
         #[arg(long, env, default_value_t = 100)]
         vm_watermark_scale_factor: usize,
     },
+    /// Don't do anything, just sleep.
+    /// This allows us to not need a separate image just to keep
+    /// the daemonset alive after we have initialized things.
+    Sleep,
 }
 
 #[derive(Parser)]
@@ -126,5 +133,8 @@ fn main() {
                     .setup(),
                 )
         }
+        Commands::Sleep => loop {
+            sleep(Duration::from_secs(3600));
+        },
     }
 }


### PR DESCRIPTION
Adds a `sleep` subcommand.

This is useful for:
1. Not needing to pull a separate image. This should slightly speed up initialization.
2. Simplifying configuration. The `pause` image is cloud-provider specific, which makes it harder to find and configure.