### PR TITLE
Fix bug when identifying non NVME labeled disks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -252,7 +252,7 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "ephemeral-storage-setup"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "clap",
  "k8s-openapi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ephemeral-storage-setup"
-version = "0.3.2"
+version = "0.3.3"
 edition = "2024"
 rust-version = "1.88.0"
 resolver = "2"

--- a/src/detect.rs
+++ b/src/detect.rs
@@ -170,7 +170,12 @@ impl DiskDetector {
         // filter to local SSDs. We don't only use `find`
         // because the devices might have partitions or other
         // children we need to filter out.
-        let find_paths = self.find("/dev/disk/by-id", "google-local-nvme-ssd-*");
+        // All local disks will take the form of google-local-*.
+        // We'll make the assumption that the machine has homogeneous
+        // disk setup, and that the disks the user configured or are
+        // provided by the machine are NVME or equivilently fast.
+        let find_paths = [self.find("/dev/disk/by-id", "google-local-*")].concat();
+
         self.lsblk()
             .paths()
             .filter(|path| find_paths.contains(path))


### PR DESCRIPTION
This will allow any google-local disk, and we'll leave it
up to the user to follow our guidance about NVME.
