### PR TITLE
Change taint name

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -252,7 +252,7 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "ephemeral-storage-setup"
-version = "0.3.4"
+version = "0.4.0"
 dependencies = [
  "clap",
  "k8s-openapi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ephemeral-storage-setup"
-version = "0.3.4"
+version = "0.4.0"
 edition = "2024"
 rust-version = "1.88.0"
 resolver = "2"

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ resource "kubernetes_daemonset" "disk_setup" {
         }
         # Node taint to prevent regular workloads from being scheduled until disks are configured
         toleration {
-          key      = "disk-unconfigured"
+          key      = "startup-taint.cluster-autoscaler.kubernetes.io/disk-unconfigured"
           operator = "Exists"
           effect   = "NoSchedule"
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -91,7 +91,11 @@ struct CommonArgs {
     node_name: Option<String>,
 
     /// Name of the taint to remove.
-    #[clap(long, env, default_value = "disk-unconfigured")]
+    #[clap(
+        long,
+        env,
+        default_value = "startup-taint.cluster-autoscaler.kubernetes.io/disk-unconfigured"
+    )]
     taint_key: String,
 
     #[clap(long, env, requires_if("true", "node_name"))]


### PR DESCRIPTION
Change default taint name to match GCP's expectation about startup taints. If the name doesn't start with their expected prefix, the cluster-autoscaler won't create nodes.