### PR TITLE
Update labels/selectors in examples

### DIFF
--- a/examples/azure/lvm.yaml
+++ b/examples/azure/lvm.yaml
@@ -34,18 +34,18 @@ subjects:
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  name: disk-setup
+  name: disk-setup-scratchfs
   namespace: disk-setup
   labels:
-    app: materialize-disk-setup
+    app: materialize-disk-setup-scratchfs
 spec:
   selector:
     matchLabels:
-      app: materialize-disk-setup
+      app: materialize-disk-setup-scratchfs
   template:
     metadata:
       labels:
-        app: materialize-disk-setup
+        app: materialize-disk-setup-scratchfs
     spec:
       securityContext:
         runAsNonRoot: false
@@ -58,7 +58,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: materialize.cloud/disk
+              - key: materialize.cloud/scratch-fs
                 operator: In
                 values: ["true"]
       tolerations:

--- a/examples/azure/swap.yaml
+++ b/examples/azure/swap.yaml
@@ -34,18 +34,18 @@ subjects:
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  name: disk-setup
+  name: disk-setup-swap
   namespace: disk-setup
   labels:
-    app: materialize-disk-setup
+    app: materialize-disk-setup-swap
 spec:
   selector:
     matchLabels:
-      app: materialize-disk-setup
+      app: materialize-disk-setup-swap
   template:
     metadata:
       labels:
-        app: materialize-disk-setup
+        app: materialize-disk-setup-swap
     spec:
       securityContext:
         runAsNonRoot: false
@@ -58,7 +58,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: materialize.cloud/disk
+              - key: materialize.cloud/swap
                 operator: In
                 values: ["true"]
       tolerations:

--- a/examples/gcp/lvm.yaml
+++ b/examples/gcp/lvm.yaml
@@ -34,18 +34,18 @@ subjects:
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  name: disk-setup
+  name: disk-setup-scratchfs
   namespace: disk-setup
   labels:
-    app: materialize-disk-setup
+    app: materialize-disk-setup-scratchfs
 spec:
   selector:
     matchLabels:
-      app: materialize-disk-setup
+      app: materialize-disk-setup-scratchfs
   template:
     metadata:
       labels:
-        app: materialize-disk-setup
+        app: materialize-disk-setup-scratchfs
     spec:
       securityContext:
         runAsNonRoot: false
@@ -58,7 +58,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: materialize.cloud/disk
+              - key: materialize.cloud/scratch-fs
                 operator: In
                 values: ["true"]
       tolerations:

--- a/examples/gcp/swap.yaml
+++ b/examples/gcp/swap.yaml
@@ -34,18 +34,18 @@ subjects:
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  name: disk-setup
+  name: disk-setup-swap
   namespace: disk-setup
   labels:
-    app: materialize-disk-setup
+    app: materialize-disk-setup-swap
 spec:
   selector:
     matchLabels:
-      app: materialize-disk-setup
+      app: materialize-disk-setup-swap
   template:
     metadata:
       labels:
-        app: materialize-disk-setup
+        app: materialize-disk-setup-swap
     spec:
       securityContext:
         runAsNonRoot: false
@@ -58,7 +58,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: materialize.cloud/disk
+              - key: materialize.cloud/swap
                 operator: In
                 values: ["true"]
       tolerations:


### PR DESCRIPTION
Updates the labels and selectors in our examples to more easily allow users to transition between LVM and swap configurations. The new labels/selectors should force the daemonsets to only go to nodes labeled for their respective use cases.