### PR TITLE
Change swapon to set identical priority for devices

### DIFF
--- a/src/swap.rs
+++ b/src/swap.rs
@@ -103,7 +103,10 @@ Environment="KUBELET_CONFIG_FILE_FLAGS=--config /var/lib/kubelet/config.yaml""#,
     }
 
     fn swapon(&self, device: &str) {
-        self.commander.check_output(&["swapon", device]);
+        // Explicitly set all devices to the same priority, so Linux will
+        // allocate pages to disks round-robin, allowing for faster I/O
+        // on machines with multiple disks.
+        self.commander.check_output(&["swapon", "-p", "10", device]);
     }
 
     fn is_existing_swap(&self, device: &str) -> bool {


### PR DESCRIPTION
Many of our workloads on Materialize are bound by swap I/O performance currently. From looking at some statistics, I discovered that it was only using one of our disks assigned to swap.

I realized that the current behavior of epehemeral-storage-setup is to call swapon in order with no priority, which results in descending priority order for the disks, so basically the first disk mounted will get written to first until it's full, and so on:

```
/ # cat /proc/swaps
Filename				Type		Size		Used		Priority
/nvme0n1                                partition	393215996	290874380	-2
/nvme0n2                                partition	393215996	5588		-3
/nvme0n3                                partition	393215996	0		-4
/nvme0n4                                partition	393215996	0		-5
/nvme0n5                                partition	393215996	0		-6
/nvme0n6                                partition	393215996	0		-7
/nvme0n7                                partition	393215996	0		-8
/nvme0n8                                partition	393215996	0		-9
```

Per [swapon(2)](https://man.archlinux.org/man/swapon.2.en.txt), setting the same priority should result in round-robin allocation:

       Swap pages are allocated from areas in priority order, highest priority
       first.  For areas with different priorities, a higher-priority area is
       exhausted before using a lower-priority area.  If two or more areas
       have the same priority, and it is the highest priority available, pages
       are allocated on a round-robin basis between them.

This is marked as a draft for the following reasons:
1. I haven't tested it.
2. It is unclear if it will actually improve performance. One could imagine that having pages scattered all over the place could in theory cause issues with sequential read performance due to the accesses being colder and more cache misses. However, I'm very hopeful.