### PR TITLE
Set read_ahead_kb to 20MB (configurable)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -100,6 +100,11 @@ struct CommonArgs {
 
     #[clap(long, env, requires_if("true", "node_name"))]
     remove_taint: bool,
+
+    /// Set the read-ahead buffer size (in KB) for all detected devices.
+    /// This controls how much data the kernel prefetches when reading from disk.
+    #[arg(long, env, default_value_t = 20480)]
+    read_ahead_kb: usize,
 }
 
 fn print_help_and_exit() -> ! {
@@ -149,6 +154,7 @@ fn main() {
                     node_name,
                     taint_key,
                     remove_taint,
+                    read_ahead_kb,
                 },
             vg_name,
         } => {
@@ -165,6 +171,7 @@ fn main() {
                         taint_key,
                         remove_taint,
                         vg_name,
+                        read_ahead_kb,
                     }
                     .setup(),
                 )
@@ -176,6 +183,7 @@ fn main() {
                     node_name,
                     taint_key,
                     remove_taint,
+                    read_ahead_kb,
                 },
             bottlerocket_enable_swap,
             hack_restart_kubelet_enable_swap,
@@ -203,6 +211,7 @@ fn main() {
                         vm_swappiness,
                         vm_min_free_kbytes,
                         vm_watermark_scale_factor,
+                        read_ahead_kb,
                     }
                     .setup(),
                 )


### PR DESCRIPTION
Set [read_ahead_kb](https://www.kernel.org/doc/html/v5.3/block/queue-sysfs.html#read-ahead-kb-rw) to 20MB (configurable) (up from Linux default of 128KB) for all detected devices.

* Linux has many heuristics for deciding when to read ahead. It will generally only do it when it has detected some sort of sequential reading behavior, or when madvise'd to read sequentially. Hopefully, this PR will not cause large issues on non-sequential workloads.
* Materialize does lots of sequential reading, so hopefully this will lead to benefits when the kernel detects sequential reading. We have seen on some of our workloads that we are being bottlenecked probably on serialization of disk reads / lack of pipelining.

I'm not so sure exactly how effective this will be when swap is getting striped across multiple disks, but it seems worth trying.

This PR is untested, and the exact value may need tuning.